### PR TITLE
Add height reminders contract example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Athena Consulting has been awarded a grant by [Atom Accelerator DAO](https://www
 - [TimeLock Contract](https://github.com/athena-consulting/cosmwasm-by-example/tree/main/timelock)
 - [Crowdfunding Contract](https://github.com/athena-consulting/cosmwasm-by-example/tree/main/crowdfunding)
 - [Token Vault](https://github.com/athena-consulting/cosmwasm-by-example/tree/main/token-vault)
+- [Height Reminders](https://github.com/athena-consulting/cosmwasm-by-example/tree/main/height-reminders)
 
 ### :three: Complex Applications
 - [Constant Product AMM](https://github.com/athena-consulting/cosmwasm-by-example/tree/main/constant-product-amm)

--- a/height-reminders/Cargo.toml
+++ b/height-reminders/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "height-reminders"
+version = "0.1.0"
+authors = ["kaycke1337"]
+edition = "2021"
+
+exclude = [
+  "contract.wasm",
+  "hash.txt",
+]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
+[features]
+backtraces = ["cosmwasm-std/backtraces"]
+library = []
+
+[dependencies]
+cosmwasm-schema = "1.1.3"
+cosmwasm-std = "1.1.3"
+cw-storage-plus = "1.0.1"
+cw2 = "1.0.1"
+schemars = "0.8.10"
+serde = { version = "1.0.145", default-features = false, features = ["derive"] }
+thiserror = "1.0.31"

--- a/height-reminders/README.md
+++ b/height-reminders/README.md
@@ -1,0 +1,21 @@
+# Height Reminders
+
+This example stores simple block-height reminders.
+
+A user creates a reminder with a unique ID, a due block height, and a short note.
+The creator can cancel it before it is due. Once the chain reaches the due
+height, anyone can mark it as complete. This demonstrates:
+
+- storing multiple records with `cw-storage-plus::Map`
+- validating message data during execution
+- checking `env.block.height`
+- enforcing creator-only cancellation
+- querying individual reminders and all known reminder IDs
+
+## Flow
+
+1. Instantiate the contract.
+2. Call `CreateReminder` with an ID, due height, and note.
+3. Query the reminder by ID or list all IDs.
+4. Before the due height, the creator can cancel the reminder.
+5. At or after the due height, anyone can complete it.

--- a/height-reminders/src/bin/schema.rs
+++ b/height-reminders/src/bin/schema.rs
@@ -1,0 +1,10 @@
+use cosmwasm_schema::write_api;
+use height_reminders::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg,
+    }
+}

--- a/height-reminders/src/contract.rs
+++ b/height-reminders/src/contract.rs
@@ -1,0 +1,359 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Order, Response, StdResult,
+};
+use cw2::set_contract_version;
+
+use crate::error::ContractError;
+use crate::msg::{
+    ConfigResponse, ExecuteMsg, InstantiateMsg, ListRemindersResponse, QueryMsg, ReminderResponse,
+};
+use crate::state::{Config, Reminder, CONFIG, REMINDERS};
+
+const CONTRACT_NAME: &str = "crates.io:height-reminders";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    _msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    CONFIG.save(
+        deps.storage,
+        &Config {
+            owner: info.sender.clone(),
+        },
+    )?;
+
+    Ok(Response::new()
+        .add_attribute("method", "instantiate")
+        .add_attribute("owner", info.sender))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::CreateReminder {
+            id,
+            due_height,
+            note,
+        } => execute_create_reminder(deps, info, id, due_height, note),
+        ExecuteMsg::CompleteReminder { id } => execute_complete_reminder(deps, env, id),
+        ExecuteMsg::CancelReminder { id } => execute_cancel_reminder(deps, info, id),
+    }
+}
+
+fn execute_create_reminder(
+    deps: DepsMut,
+    info: MessageInfo,
+    id: String,
+    due_height: u64,
+    note: String,
+) -> Result<Response, ContractError> {
+    let id = id.trim().to_string();
+    let note = note.trim().to_string();
+    if id.is_empty() || note.is_empty() {
+        return Err(ContractError::EmptyField {});
+    }
+    if REMINDERS.has(deps.storage, &id) {
+        return Err(ContractError::ReminderExists {});
+    }
+
+    let reminder = Reminder {
+        id: id.clone(),
+        creator: info.sender,
+        due_height,
+        note,
+        completed: false,
+    };
+    REMINDERS.save(deps.storage, &id, &reminder)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "create_reminder")
+        .add_attribute("id", id)
+        .add_attribute("due_height", due_height.to_string()))
+}
+
+fn execute_complete_reminder(
+    deps: DepsMut,
+    env: Env,
+    id: String,
+) -> Result<Response, ContractError> {
+    REMINDERS.update(deps.storage, &id, |record| -> Result<_, ContractError> {
+        let mut reminder = record.ok_or(ContractError::ReminderNotFound {})?;
+        if env.block.height < reminder.due_height {
+            return Err(ContractError::NotDue {});
+        }
+        reminder.completed = true;
+        Ok(reminder)
+    })?;
+
+    Ok(Response::new()
+        .add_attribute("action", "complete_reminder")
+        .add_attribute("id", id))
+}
+
+fn execute_cancel_reminder(
+    deps: DepsMut,
+    info: MessageInfo,
+    id: String,
+) -> Result<Response, ContractError> {
+    let reminder = REMINDERS
+        .load(deps.storage, &id)
+        .map_err(|_| ContractError::ReminderNotFound {})?;
+    if reminder.creator != info.sender {
+        return Err(ContractError::Unauthorized {});
+    }
+    REMINDERS.remove(deps.storage, &id);
+
+    Ok(Response::new()
+        .add_attribute("action", "cancel_reminder")
+        .add_attribute("id", id))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Reminder { id } => to_json_binary(&query_reminder(deps, id)?),
+        QueryMsg::ListReminders {} => to_json_binary(&query_reminders(deps)?),
+        QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
+    }
+}
+
+fn query_reminder(deps: Deps, id: String) -> StdResult<ReminderResponse> {
+    let reminder = REMINDERS.load(deps.storage, &id)?;
+    Ok(ReminderResponse { reminder })
+}
+
+fn query_reminders(deps: Deps) -> StdResult<ListRemindersResponse> {
+    let ids = REMINDERS
+        .keys(deps.storage, None, None, Order::Ascending)
+        .collect::<StdResult<Vec<String>>>()?;
+    Ok(ListRemindersResponse { ids })
+}
+
+fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
+    let config = CONFIG.load(deps.storage)?;
+    Ok(ConfigResponse {
+        owner: config.owner,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::from_json;
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+
+    fn init() -> cosmwasm_std::OwnedDeps<
+        cosmwasm_std::MemoryStorage,
+        cosmwasm_std::testing::MockApi,
+        cosmwasm_std::testing::MockQuerier,
+    > {
+        let mut deps = mock_dependencies();
+        instantiate(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("owner", &[]),
+            InstantiateMsg {},
+        )
+        .unwrap();
+        deps
+    }
+
+    #[test]
+    fn creates_and_queries_reminder() {
+        let mut deps = init();
+
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("alice", &[]),
+            ExecuteMsg::CreateReminder {
+                id: "renewal".to_string(),
+                due_height: 100,
+                note: "Renew validator delegation".to_string(),
+            },
+        )
+        .unwrap();
+
+        let res = query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::Reminder {
+                id: "renewal".to_string(),
+            },
+        )
+        .unwrap();
+        let value: ReminderResponse = from_json(&res).unwrap();
+        assert_eq!(
+            value.reminder.creator,
+            cosmwasm_std::Addr::unchecked("alice")
+        );
+        assert_eq!(value.reminder.due_height, 100);
+        assert!(!value.reminder.completed);
+    }
+
+    #[test]
+    fn blocks_duplicate_and_empty_reminders() {
+        let mut deps = init();
+        let msg = ExecuteMsg::CreateReminder {
+            id: "renewal".to_string(),
+            due_height: 100,
+            note: "Renew validator delegation".to_string(),
+        };
+
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("alice", &[]),
+            msg.clone(),
+        )
+        .unwrap();
+        let err = execute(deps.as_mut(), mock_env(), mock_info("alice", &[]), msg).unwrap_err();
+        assert_eq!(err, ContractError::ReminderExists {});
+
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("alice", &[]),
+            ExecuteMsg::CreateReminder {
+                id: " ".to_string(),
+                due_height: 100,
+                note: "note".to_string(),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::EmptyField {});
+    }
+
+    #[test]
+    fn completes_only_after_due_height() {
+        let mut deps = init();
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("alice", &[]),
+            ExecuteMsg::CreateReminder {
+                id: "go-live".to_string(),
+                due_height: 25,
+                note: "Launch checklist".to_string(),
+            },
+        )
+        .unwrap();
+
+        let mut env = mock_env();
+        env.block.height = 24;
+        let err = execute(
+            deps.as_mut(),
+            env,
+            mock_info("bob", &[]),
+            ExecuteMsg::CompleteReminder {
+                id: "go-live".to_string(),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::NotDue {});
+
+        let mut env = mock_env();
+        env.block.height = 25;
+        execute(
+            deps.as_mut(),
+            env,
+            mock_info("bob", &[]),
+            ExecuteMsg::CompleteReminder {
+                id: "go-live".to_string(),
+            },
+        )
+        .unwrap();
+
+        let res = query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::Reminder {
+                id: "go-live".to_string(),
+            },
+        )
+        .unwrap();
+        let value: ReminderResponse = from_json(&res).unwrap();
+        assert!(value.reminder.completed);
+    }
+
+    #[test]
+    fn only_creator_can_cancel() {
+        let mut deps = init();
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("alice", &[]),
+            ExecuteMsg::CreateReminder {
+                id: "tax".to_string(),
+                due_height: 30,
+                note: "Prepare report".to_string(),
+            },
+        )
+        .unwrap();
+
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("bob", &[]),
+            ExecuteMsg::CancelReminder {
+                id: "tax".to_string(),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::Unauthorized {});
+
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("alice", &[]),
+            ExecuteMsg::CancelReminder {
+                id: "tax".to_string(),
+            },
+        )
+        .unwrap();
+
+        let err = query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::Reminder {
+                id: "tax".to_string(),
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn lists_reminder_ids() {
+        let mut deps = init();
+        for id in ["b", "a"] {
+            execute(
+                deps.as_mut(),
+                mock_env(),
+                mock_info("alice", &[]),
+                ExecuteMsg::CreateReminder {
+                    id: id.to_string(),
+                    due_height: 10,
+                    note: format!("note {id}"),
+                },
+            )
+            .unwrap();
+        }
+
+        let res = query(deps.as_ref(), mock_env(), QueryMsg::ListReminders {}).unwrap();
+        let value: ListRemindersResponse = from_json(&res).unwrap();
+        assert_eq!(value.ids, vec!["a".to_string(), "b".to_string()]);
+    }
+}

--- a/height-reminders/src/error.rs
+++ b/height-reminders/src/error.rs
@@ -1,0 +1,23 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Reminder already exists")]
+    ReminderExists {},
+
+    #[error("Reminder not found")]
+    ReminderNotFound {},
+
+    #[error("Reminder is not due yet")]
+    NotDue {},
+
+    #[error("Only the creator can cancel this reminder")]
+    Unauthorized {},
+
+    #[error("Reminder id and note cannot be empty")]
+    EmptyField {},
+}

--- a/height-reminders/src/lib.rs
+++ b/height-reminders/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod contract;
+mod error;
+pub mod msg;
+pub mod state;
+
+pub use crate::error::ContractError;

--- a/height-reminders/src/msg.rs
+++ b/height-reminders/src/msg.rs
@@ -1,0 +1,48 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::Addr;
+
+use crate::state::Reminder;
+
+#[cw_serde]
+pub struct InstantiateMsg {}
+
+#[cw_serde]
+pub enum ExecuteMsg {
+    CreateReminder {
+        id: String,
+        due_height: u64,
+        note: String,
+    },
+    CompleteReminder {
+        id: String,
+    },
+    CancelReminder {
+        id: String,
+    },
+}
+
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    #[returns(ReminderResponse)]
+    Reminder { id: String },
+    #[returns(ListRemindersResponse)]
+    ListReminders {},
+    #[returns(ConfigResponse)]
+    Config {},
+}
+
+#[cw_serde]
+pub struct ReminderResponse {
+    pub reminder: Reminder,
+}
+
+#[cw_serde]
+pub struct ListRemindersResponse {
+    pub ids: Vec<String>,
+}
+
+#[cw_serde]
+pub struct ConfigResponse {
+    pub owner: Addr,
+}

--- a/height-reminders/src/state.rs
+++ b/height-reminders/src/state.rs
@@ -1,0 +1,20 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Addr;
+use cw_storage_plus::{Item, Map};
+
+#[cw_serde]
+pub struct Config {
+    pub owner: Addr,
+}
+
+#[cw_serde]
+pub struct Reminder {
+    pub id: String,
+    pub creator: Addr,
+    pub due_height: u64,
+    pub note: String,
+    pub completed: bool,
+}
+
+pub const CONFIG: Item<Config> = Item::new("config");
+pub const REMINDERS: Map<&str, Reminder> = Map::new("reminders");


### PR DESCRIPTION
Refs #11.

## Summary
- Add an original `height-reminders` CosmWasm example contract.
- Demonstrates `cw-storage-plus::Map`, creator-only cancellation, block-height validation, completion state, and list/detail queries.
- Add README coverage and link the example from the root README.
- Use current CosmWasm JSON helpers (`to_json_binary` / `from_json`) so the focused tests run without deprecation warnings.

## Validation
- `cargo fmt --manifest-path height-reminders/Cargo.toml --check`
- `cargo test --manifest-path height-reminders/Cargo.toml` (5 passed)
- `git diff --check`

## Bounty/contact
This is an original simple-tier contract example for #11. Contact: GitHub @kaycke1337. Payout details can be provided privately if accepted.