### PR TITLE
Add expiring announcements contract example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Athena Consulting has been awarded a grant by [Atom Accelerator DAO](https://www
 - [TimeLock Contract](https://github.com/athena-consulting/cosmwasm-by-example/tree/main/timelock)
 - [Crowdfunding Contract](https://github.com/athena-consulting/cosmwasm-by-example/tree/main/crowdfunding)
 - [Token Vault](https://github.com/athena-consulting/cosmwasm-by-example/tree/main/token-vault)
+- [Expiring Announcements](https://github.com/athena-consulting/cosmwasm-by-example/tree/main/expiring-announcements)
 
 ### :three: Complex Applications
 - [Constant Product AMM](https://github.com/athena-consulting/cosmwasm-by-example/tree/main/constant-product-amm)

--- a/expiring-announcements/Cargo.toml
+++ b/expiring-announcements/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "expiring-announcements"
+version = "0.1.0"
+authors = ["kaycke1337"]
+edition = "2021"
+
+exclude = [
+  "contract.wasm",
+  "hash.txt",
+]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
+[features]
+backtraces = ["cosmwasm-std/backtraces"]
+library = []
+
+[dependencies]
+cosmwasm-schema = "1.1.3"
+cosmwasm-std = "1.1.3"
+cw-storage-plus = "1.0.1"
+cw2 = "1.0.1"
+schemars = "0.8.10"
+serde = { version = "1.0.145", default-features = false, features = ["derive"] }
+thiserror = "1.0.31"

--- a/expiring-announcements/README.md
+++ b/expiring-announcements/README.md
@@ -1,0 +1,24 @@
+# Expiring Announcements
+
+This example stores owner-managed announcements that expire at a chosen block
+height.
+
+It is useful for learning how a contract can keep public records available while
+letting queries distinguish active notices from expired or archived ones. This
+demonstrates:
+
+- owner-only execution
+- multiple records stored with `cw-storage-plus::Map`
+- validation of empty fields and duplicate IDs
+- block-height expiry checks with `env.block.height`
+- paginated-style list queries with an active-only filter
+
+## Flow
+
+1. Instantiate the contract. The sender becomes the owner.
+2. The owner publishes an announcement with an ID, title, body, and expiration
+   height.
+3. Anyone can query a specific announcement or list announcements.
+4. The owner can archive an announcement before or after it expires.
+5. Active-only list queries omit archived announcements and announcements whose
+   expiration height has passed.

--- a/expiring-announcements/src/bin/schema.rs
+++ b/expiring-announcements/src/bin/schema.rs
@@ -1,0 +1,10 @@
+use cosmwasm_schema::write_api;
+use expiring_announcements::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg,
+    }
+}

--- a/expiring-announcements/src/contract.rs
+++ b/expiring-announcements/src/contract.rs
@@ -1,0 +1,378 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Order, Response, StdResult,
+};
+use cw2::set_contract_version;
+
+use crate::error::ContractError;
+use crate::msg::{
+    AnnouncementResponse, ConfigResponse, ExecuteMsg, InstantiateMsg, ListAnnouncementsResponse,
+    QueryMsg,
+};
+use crate::state::{Announcement, Config, ANNOUNCEMENTS, CONFIG};
+
+const CONTRACT_NAME: &str = "crates.io:expiring-announcements";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    _msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    CONFIG.save(
+        deps.storage,
+        &Config {
+            owner: info.sender.clone(),
+        },
+    )?;
+
+    Ok(Response::new()
+        .add_attribute("method", "instantiate")
+        .add_attribute("owner", info.sender))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::Publish {
+            id,
+            title,
+            body,
+            expires_at,
+        } => execute_publish(deps, env, info, id, title, body, expires_at),
+        ExecuteMsg::Archive { id } => execute_archive(deps, info, id),
+        ExecuteMsg::TransferOwnership { new_owner } => {
+            execute_transfer_ownership(deps, info, new_owner)
+        }
+    }
+}
+
+fn assert_owner(deps: Deps, info: &MessageInfo) -> Result<(), ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    if config.owner != info.sender {
+        return Err(ContractError::Unauthorized {});
+    }
+    Ok(())
+}
+
+fn execute_publish(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    id: String,
+    title: String,
+    body: String,
+    expires_at: u64,
+) -> Result<Response, ContractError> {
+    assert_owner(deps.as_ref(), &info)?;
+
+    let id = id.trim().to_string();
+    let title = title.trim().to_string();
+    let body = body.trim().to_string();
+    if id.is_empty() || title.is_empty() || body.is_empty() {
+        return Err(ContractError::EmptyField {});
+    }
+    if expires_at <= env.block.height {
+        return Err(ContractError::InvalidExpiration {});
+    }
+    if ANNOUNCEMENTS.has(deps.storage, &id) {
+        return Err(ContractError::AnnouncementExists {});
+    }
+
+    let announcement = Announcement {
+        id: id.clone(),
+        title,
+        body,
+        expires_at,
+        archived: false,
+    };
+    ANNOUNCEMENTS.save(deps.storage, &id, &announcement)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "publish")
+        .add_attribute("id", id)
+        .add_attribute("expires_at", expires_at.to_string()))
+}
+
+fn execute_archive(
+    deps: DepsMut,
+    info: MessageInfo,
+    id: String,
+) -> Result<Response, ContractError> {
+    assert_owner(deps.as_ref(), &info)?;
+    ANNOUNCEMENTS.update(deps.storage, &id, |record| -> Result<_, ContractError> {
+        let mut announcement = record.ok_or(ContractError::AnnouncementNotFound {})?;
+        announcement.archived = true;
+        Ok(announcement)
+    })?;
+
+    Ok(Response::new()
+        .add_attribute("action", "archive")
+        .add_attribute("id", id))
+}
+
+fn execute_transfer_ownership(
+    deps: DepsMut,
+    info: MessageInfo,
+    new_owner: String,
+) -> Result<Response, ContractError> {
+    assert_owner(deps.as_ref(), &info)?;
+    let new_owner_addr = deps.api.addr_validate(new_owner.trim())?;
+    CONFIG.update(deps.storage, |mut config| -> Result<_, ContractError> {
+        config.owner = new_owner_addr.clone();
+        Ok(config)
+    })?;
+
+    Ok(Response::new()
+        .add_attribute("action", "transfer_ownership")
+        .add_attribute("new_owner", new_owner_addr))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
+        QueryMsg::Announcement { id } => to_json_binary(&query_announcement(deps, env, id)?),
+        QueryMsg::List { active_only } => {
+            to_json_binary(&query_list(deps, env, active_only.unwrap_or(false))?)
+        }
+    }
+}
+
+fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
+    let config = CONFIG.load(deps.storage)?;
+    Ok(ConfigResponse {
+        owner: config.owner,
+    })
+}
+
+fn query_announcement(deps: Deps, env: Env, id: String) -> StdResult<AnnouncementResponse> {
+    let announcement = ANNOUNCEMENTS.load(deps.storage, &id)?;
+    let active = is_active(&announcement, env.block.height);
+    Ok(AnnouncementResponse {
+        announcement,
+        active,
+    })
+}
+
+fn query_list(deps: Deps, env: Env, active_only: bool) -> StdResult<ListAnnouncementsResponse> {
+    let announcements = ANNOUNCEMENTS
+        .range(deps.storage, None, None, Order::Ascending)
+        .filter_map(|item| match item {
+            Ok((_id, announcement)) => {
+                let active = is_active(&announcement, env.block.height);
+                if active_only && !active {
+                    None
+                } else {
+                    Some(Ok(AnnouncementResponse {
+                        announcement,
+                        active,
+                    }))
+                }
+            }
+            Err(err) => Some(Err(err)),
+        })
+        .collect::<StdResult<Vec<_>>>()?;
+    Ok(ListAnnouncementsResponse { announcements })
+}
+
+fn is_active(announcement: &Announcement, block_height: u64) -> bool {
+    !announcement.archived && block_height < announcement.expires_at
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::from_json;
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+
+    fn init() -> cosmwasm_std::OwnedDeps<
+        cosmwasm_std::MemoryStorage,
+        cosmwasm_std::testing::MockApi,
+        cosmwasm_std::testing::MockQuerier,
+    > {
+        let mut deps = mock_dependencies();
+        instantiate(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("owner", &[]),
+            InstantiateMsg {},
+        )
+        .unwrap();
+        deps
+    }
+
+    fn publish(id: &str, expires_at: u64) -> ExecuteMsg {
+        ExecuteMsg::Publish {
+            id: id.to_string(),
+            title: format!("Title {id}"),
+            body: format!("Body {id}"),
+            expires_at,
+        }
+    }
+
+    #[test]
+    fn owner_can_publish_and_query_active_announcement() {
+        let mut deps = init();
+        let mut env = mock_env();
+        env.block.height = 10;
+
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            mock_info("owner", &[]),
+            publish("maintenance", 20),
+        )
+        .unwrap();
+
+        let res = query(
+            deps.as_ref(),
+            env,
+            QueryMsg::Announcement {
+                id: "maintenance".to_string(),
+            },
+        )
+        .unwrap();
+        let value: AnnouncementResponse = from_json(&res).unwrap();
+        assert_eq!(value.announcement.id, "maintenance");
+        assert!(value.active);
+    }
+
+    #[test]
+    fn rejects_unauthorized_or_invalid_publish() {
+        let mut deps = init();
+        let mut env = mock_env();
+        env.block.height = 10;
+
+        let err = execute(
+            deps.as_mut(),
+            env.clone(),
+            mock_info("intruder", &[]),
+            publish("notice", 20),
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::Unauthorized {});
+
+        let err = execute(
+            deps.as_mut(),
+            env.clone(),
+            mock_info("owner", &[]),
+            publish("notice", 10),
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::InvalidExpiration {});
+
+        let err = execute(
+            deps.as_mut(),
+            env,
+            mock_info("owner", &[]),
+            ExecuteMsg::Publish {
+                id: " ".to_string(),
+                title: "title".to_string(),
+                body: "body".to_string(),
+                expires_at: 20,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::EmptyField {});
+    }
+
+    #[test]
+    fn blocks_duplicate_ids() {
+        let mut deps = init();
+        let mut env = mock_env();
+        env.block.height = 10;
+
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            mock_info("owner", &[]),
+            publish("notice", 20),
+        )
+        .unwrap();
+        let err = execute(
+            deps.as_mut(),
+            env,
+            mock_info("owner", &[]),
+            publish("notice", 25),
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::AnnouncementExists {});
+    }
+
+    #[test]
+    fn active_filter_omits_expired_and_archived_announcements() {
+        let mut deps = init();
+        let mut env = mock_env();
+        env.block.height = 10;
+
+        for (id, expires_at) in [("active", 30), ("expired", 15), ("archived", 30)] {
+            execute(
+                deps.as_mut(),
+                env.clone(),
+                mock_info("owner", &[]),
+                publish(id, expires_at),
+            )
+            .unwrap();
+        }
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            mock_info("owner", &[]),
+            ExecuteMsg::Archive {
+                id: "archived".to_string(),
+            },
+        )
+        .unwrap();
+
+        env.block.height = 20;
+        let res = query(
+            deps.as_ref(),
+            env,
+            QueryMsg::List {
+                active_only: Some(true),
+            },
+        )
+        .unwrap();
+        let value: ListAnnouncementsResponse = from_json(&res).unwrap();
+        assert_eq!(value.announcements.len(), 1);
+        assert_eq!(value.announcements[0].announcement.id, "active");
+        assert!(value.announcements[0].active);
+    }
+
+    #[test]
+    fn ownership_can_be_transferred() {
+        let mut deps = init();
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("owner", &[]),
+            ExecuteMsg::TransferOwnership {
+                new_owner: "new-owner".to_string(),
+            },
+        )
+        .unwrap();
+
+        let res = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
+        let value: ConfigResponse = from_json(&res).unwrap();
+        assert_eq!(value.owner, cosmwasm_std::Addr::unchecked("new-owner"));
+
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("owner", &[]),
+            publish("old-owner-notice", 20),
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::Unauthorized {});
+    }
+}

--- a/expiring-announcements/src/error.rs
+++ b/expiring-announcements/src/error.rs
@@ -1,0 +1,23 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+
+    #[error("Announcement already exists")]
+    AnnouncementExists {},
+
+    #[error("Announcement not found")]
+    AnnouncementNotFound {},
+
+    #[error("Announcement id, title, and body cannot be empty")]
+    EmptyField {},
+
+    #[error("Expiration height must be in the future")]
+    InvalidExpiration {},
+}

--- a/expiring-announcements/src/lib.rs
+++ b/expiring-announcements/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod contract;
+mod error;
+pub mod msg;
+pub mod state;
+
+pub use crate::error::ContractError;

--- a/expiring-announcements/src/msg.rs
+++ b/expiring-announcements/src/msg.rs
@@ -1,0 +1,50 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::Addr;
+
+use crate::state::Announcement;
+
+#[cw_serde]
+pub struct InstantiateMsg {}
+
+#[cw_serde]
+pub enum ExecuteMsg {
+    Publish {
+        id: String,
+        title: String,
+        body: String,
+        expires_at: u64,
+    },
+    Archive {
+        id: String,
+    },
+    TransferOwnership {
+        new_owner: String,
+    },
+}
+
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    #[returns(ConfigResponse)]
+    Config {},
+    #[returns(AnnouncementResponse)]
+    Announcement { id: String },
+    #[returns(ListAnnouncementsResponse)]
+    List { active_only: Option<bool> },
+}
+
+#[cw_serde]
+pub struct ConfigResponse {
+    pub owner: Addr,
+}
+
+#[cw_serde]
+pub struct AnnouncementResponse {
+    pub announcement: Announcement,
+    pub active: bool,
+}
+
+#[cw_serde]
+pub struct ListAnnouncementsResponse {
+    pub announcements: Vec<AnnouncementResponse>,
+}

--- a/expiring-announcements/src/state.rs
+++ b/expiring-announcements/src/state.rs
@@ -1,0 +1,20 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Addr;
+use cw_storage_plus::{Item, Map};
+
+#[cw_serde]
+pub struct Config {
+    pub owner: Addr,
+}
+
+#[cw_serde]
+pub struct Announcement {
+    pub id: String,
+    pub title: String,
+    pub body: String,
+    pub expires_at: u64,
+    pub archived: bool,
+}
+
+pub const CONFIG: Item<Config> = Item::new("config");
+pub const ANNOUNCEMENTS: Map<&str, Announcement> = Map::new("announcements");


### PR DESCRIPTION
Refs #11.

## Summary
- Add an original `expiring-announcements` CosmWasm example contract.
- Demonstrates owner-only execution, `cw-storage-plus::Map` record storage, block-height expiry checks, archiving, ownership transfer, and active-only list queries.
- Add README coverage and link the example from the root README.

## Validation
- `cargo fmt --manifest-path expiring-announcements/Cargo.toml --check`
- `cargo test --manifest-path expiring-announcements/Cargo.toml` (5 passed)
- `git diff --check`

## Bounty/contact
This is an original simple-tier contract example for #11. Contact: GitHub @kaycke1337. Payout details can be provided privately if accepted.