### PR TITLE
Add lottery contract example

### DIFF
--- a/lottery/.cargo/config
+++ b/lottery/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --bin schema"

--- a/lottery/.circleci/config.yml
+++ b/lottery/.circleci/config.yml
@@ -1,0 +1,61 @@
+version: 2.1
+
+executors:
+  builder:
+    docker:
+      - image: buildpack-deps:trusty
+
+jobs:
+  docker-image:
+    executor: builder
+    steps:
+      - checkout
+      - setup_remote_docker
+        docker_layer_caching: true
+      - run:
+          name: Build Docker artifact
+          command: docker build --pull -t "cosmwasm/cw-gitpod-base:${CIRCLE_SHA1}" .
+      - run:
+          name: Push application Docker image to docker hub
+          command: |
+            if [ "${CIRCLE_BRANCH}" = "master" ]; then
+              docker tag "cosmwasm/cw-gitpod-base:${CIRCLE_SHA1}" cosmwasm/cw-gitpod-base:latest
+              docker login --password-stdin -u "$DOCKER_USER" \<<<"$DOCKER_PASS"
+              docker push cosmwasm/cw-gitpod-base:latest
+              docker logout
+            fi
+
+  docker-tagged:
+    executor: builder
+    steps:
+      - checkout
+      - setup_remote_docker
+        docker_layer_caching: true
+      - run:
+          name: Push application Docker image to docker hub
+          command: |
+            docker tag "cosmwasm/cw-gitpod-base:${CIRCLE_SHA1}" "cosmwasm/cw-gitpod-base:${CIRCLE_TAG}"
+            docker login --password-stdin -u "$DOCKER_USER" \<<<"$DOCKER_PASS"
+            docker push
+            docker logout
+
+workflows:
+  version: 2
+  test-suite:
+    jobs:
+      # this is now a slow process... let's only run on master
+      - docker-image:
+          filters:
+            branches:
+              only:
+                - master
+      - docker-tagged:
+          filters:
+            tags:
+              only:
+                - /^v.*/
+            branches:
+              ignore:
+                - /.*/
+            requires:
+              - docker-image

--- a/lottery/.editorconfig
+++ b/lottery/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.rs]
+indent_size = 4

--- a/lottery/.github/workflows/Basic.yml
+++ b/lottery/.github/workflows/Basic.yml
@@ -1,0 +1,75 @@
+# Based on https://github.com/actions-rs/example/blob/master/.github/workflows/quickstart.yml
+
+on: [push, pull_request]
+
+name: Basic
+
+jobs:
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.60.0
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Run unit tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: unit-test
+          args: --locked
+        env:
+          RUST_BACKTRACE: 1
+
+      - name: Compile WASM contract
+        uses: actions-rs/cargo@v1
+        with:
+          command: wasm
+          args: --locked
+        env:
+          RUSTFLAGS: "-C link-arg=-s"
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.60.0
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+
+      - name: Generate Schema
+        uses: actions-rs/cargo@v1
+        with:
+          command: schema
+          args: --locked
+
+      - name: Schema Changes
+        # fails if any changes not committed
+        run: git diff --exit-code schema

--- a/lottery/.github/workflows/Release.yml
+++ b/lottery/.github/workflows/Release.yml
@@ -1,0 +1,35 @@
+name: release wasm
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install cargo-run-script
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-run-script
+      - name: Run cargo optimize
+        uses: actions-rs/cargo@v1
+        with:
+          command: run-script
+          args: optimize
+      - name: Get release ID
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload optimized wasm
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./artifacts/*.wasm
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true

--- a/lottery/.gitignore
+++ b/lottery/.gitignore
@@ -1,0 +1,16 @@
+# Build results
+/target
+/schema
+
+# Cargo+Git helper file (https://github.com/rust-lang/cargo/blob/0.44.1/src/cargo/sources/git/utils.rs#L320-L327)
+.cargo-ok
+
+# Text file backups
+**/*.rs.bk
+
+# macOS
+.DS_Store
+
+# IDEs
+*.iml
+.idea

--- a/lottery/Cargo.toml
+++ b/lottery/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "lottery"
+version = "0.1.0"
+authors = ["gachouchani1999 <gachouchani@ndu.edu.lb>"]
+edition = "2021"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[package.metadata.scripts]
+optimize = """docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  cosmwasm/rust-optimizer:0.12.10
+"""
+
+[dependencies]
+cosmwasm-schema = "1.1.3"
+cosmwasm-std = "1.1.3"
+cosmwasm-storage = "1.1.3"
+cw-storage-plus = "1.0.1"
+cw2 = "1.0.1"
+schemars = "0.8.10"
+serde = { version = "1.0.145", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0.31" }
+
+[dev-dependencies]
+cw-multi-test = "0.16.2"

--- a/lottery/LICENSE
+++ b/lottery/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/lottery/NOTICE
+++ b/lottery/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2023 gachouchani1999 <gachouchani@ndu.edu.lb>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/lottery/README.md
+++ b/lottery/README.md
@@ -1,0 +1,16 @@
+# Hello World Smart Contract 🌍
+
+This smart contract provides an implementation for querying a "Hello World" message.
+
+## Query Message 📩
+
+Retrieve the "Hello World" string from the smart contract using the following function:
+
+```rust
+// contract.rs
+
+pub fn query_hello_world() -> StdResult<HelloWorldResponse> {
+    // Sets the string in the struct to `HelloWorldResponse` and returns it as a response to the query
+    let hello_message = HelloWorldResponse {hello_world_message: "Hello World".to_string()};
+    Ok(hello_message)
+}

--- a/lottery/src/bin/schema.rs
+++ b/lottery/src/bin/schema.rs
@@ -1,0 +1,11 @@
+use cosmwasm_schema::write_api;
+
+use lottery::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg,
+    }
+}

--- a/lottery/src/contract.rs
+++ b/lottery/src/contract.rs
@@ -1,0 +1,146 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    to_binary, BankMsg, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, StdResult, Uint128,
+};
+
+use crate::error::ContractError;
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, WinnerResponse};
+use crate::state::{Config, CONFIG, TICKETS};
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    let config = Config {
+        ticket_price: msg.ticket_price.parse().unwrap_or(0),
+        ticket_denom: msg.ticket_denom,
+        winner: "".to_string(),
+    };
+    CONFIG.save(deps.storage, &config)?;
+    TICKETS.save(deps.storage, &vec![])?;
+    Ok(Response::new().add_attribute("action", "instantiate"))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::BuyTicket {} => execute_buy_ticket(deps, info),
+        ExecuteMsg::DrawWinner {} => execute_draw(deps, env),
+    }
+}
+
+pub fn execute_buy_ticket(deps: DepsMut, info: MessageInfo) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    if !config.winner.is_empty() {
+        return Err(ContractError::WinnerAlreadyDrawn {});
+    }
+    
+    let coin = info
+        .funds
+        .iter()
+        .find(|c| c.denom == config.ticket_denom)
+        .ok_or(ContractError::InsufficientFunds {})?;
+
+    if coin.amount.u128() < config.ticket_price {
+        return Err(ContractError::InsufficientFunds {});
+    }
+
+    let mut tickets = TICKETS.load(deps.storage)?;
+    tickets.push(info.sender.to_string());
+    TICKETS.save(deps.storage, &tickets)?;
+
+    Ok(Response::new().add_attribute("action", "buy_ticket"))
+}
+
+pub fn execute_draw(deps: DepsMut, env: Env) -> Result<Response, ContractError> {
+    let mut config = CONFIG.load(deps.storage)?;
+    if !config.winner.is_empty() {
+        return Err(ContractError::WinnerAlreadyDrawn {});
+    }
+
+    let tickets = TICKETS.load(deps.storage)?;
+    if tickets.is_empty() {
+        return Err(ContractError::NoPlayers {});
+    }
+
+    // Pseudo-random selection based on block time
+    let idx = (env.block.time.seconds() as usize) % tickets.len();
+    let winner = tickets[idx].clone();
+    
+    config.winner = winner.clone();
+    CONFIG.save(deps.storage, &config)?;
+
+    let balance = deps.querier.query_all_balances(&env.contract.address)?;
+
+    let msg = BankMsg::Send {
+        to_address: winner,
+        amount: balance,
+    };
+
+    Ok(Response::new()
+        .add_attribute("action", "draw_winner")
+        .add_message(msg))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Winner {} => to_binary(&query_winner(deps)?),
+    }
+}
+
+fn query_winner(deps: Deps) -> StdResult<WinnerResponse> {
+    let config = CONFIG.load(deps.storage)?;
+    Ok(WinnerResponse {
+        winner: config.winner,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::coins;
+
+    #[test]
+    fn proper_initialization() {
+        let mut deps = mock_dependencies();
+        let msg = InstantiateMsg {
+            ticket_price: "100".to_string(),
+            ticket_denom: "earth".to_string(),
+        };
+        let info = mock_info("creator", &[]);
+        let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+        assert_eq!(0, res.messages.len());
+    }
+
+    #[test]
+    fn test_buy_and_draw() {
+        let mut deps = mock_dependencies();
+        let msg = InstantiateMsg {
+            ticket_price: "100".to_string(),
+            ticket_denom: "earth".to_string(),
+        };
+        let info = mock_info("creator", &[]);
+        instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+        let info = mock_info("user", &coins(100, "earth"));
+        execute(deps.as_mut(), mock_env(), info, ExecuteMsg::BuyTicket {}).unwrap();
+
+        // draw
+        let mut env = mock_env();
+        env.block.time = cosmwasm_std::Timestamp::from_seconds(0);
+        let info = mock_info("creator", &[]);
+        let res = execute(deps.as_mut(), env, info, ExecuteMsg::DrawWinner {}).unwrap();
+        assert_eq!(1, res.messages.len());
+    }
+}

--- a/lottery/src/contract.rs
+++ b/lottery/src/contract.rs
@@ -16,7 +16,10 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     let config = Config {
-        ticket_price: msg.ticket_price.parse().unwrap_or(0),
+        ticket_price: msg
+            .ticket_price
+            .parse()
+            .map_err(|_| ContractError::InvalidTicketPrice {})?,
         ticket_denom: msg.ticket_denom,
         winner: "".to_string(),
     };
@@ -43,7 +46,7 @@ pub fn execute_buy_ticket(deps: DepsMut, info: MessageInfo) -> Result<Response, 
     if !config.winner.is_empty() {
         return Err(ContractError::WinnerAlreadyDrawn {});
     }
-    
+
     let coin = info
         .funds
         .iter()
@@ -75,7 +78,7 @@ pub fn execute_draw(deps: DepsMut, env: Env) -> Result<Response, ContractError> 
     // Pseudo-random selection based on block time
     let idx = (env.block.time.seconds() as usize) % tickets.len();
     let winner = tickets[idx].clone();
-    
+
     config.winner = winner.clone();
     CONFIG.save(deps.storage, &config)?;
 
@@ -121,6 +124,20 @@ mod tests {
         let info = mock_info("creator", &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(0, res.messages.len());
+    }
+
+    #[test]
+    fn reject_invalid_ticket_price() {
+        let mut deps = mock_dependencies();
+        let msg = InstantiateMsg {
+            ticket_price: "not-a-number".to_string(),
+            ticket_denom: "earth".to_string(),
+        };
+        let info = mock_info("creator", &[]);
+
+        let err = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap_err();
+
+        assert_eq!(err, ContractError::InvalidTicketPrice {});
     }
 
     #[test]

--- a/lottery/src/error.rs
+++ b/lottery/src/error.rs
@@ -1,0 +1,17 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Insufficient funds")]
+    InsufficientFunds {},
+
+    #[error("No players")]
+    NoPlayers {},
+    
+    #[error("Winner already drawn")]
+    WinnerAlreadyDrawn {},
+}

--- a/lottery/src/error.rs
+++ b/lottery/src/error.rs
@@ -11,7 +11,10 @@ pub enum ContractError {
 
     #[error("No players")]
     NoPlayers {},
-    
+
+    #[error("Invalid ticket price")]
+    InvalidTicketPrice {},
+
     #[error("Winner already drawn")]
     WinnerAlreadyDrawn {},
 }

--- a/lottery/src/lib.rs
+++ b/lottery/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod contract;
+mod error;
+pub mod helpers;
+pub mod msg;
+pub mod state;
+
+pub use crate::error::ContractError;

--- a/lottery/src/lib.rs
+++ b/lottery/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod contract;
 mod error;
-pub mod helpers;
 pub mod msg;
 pub mod state;
 

--- a/lottery/src/msg.rs
+++ b/lottery/src/msg.rs
@@ -1,0 +1,25 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+
+#[cw_serde]
+pub struct InstantiateMsg {
+    pub ticket_price: String,
+    pub ticket_denom: String,
+}
+
+#[cw_serde]
+pub enum ExecuteMsg {
+    BuyTicket {},
+    DrawWinner {},
+}
+
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    #[returns(WinnerResponse)]
+    Winner {},
+}
+
+#[cw_serde]
+pub struct WinnerResponse {
+    pub winner: String,
+}

--- a/lottery/src/state.rs
+++ b/lottery/src/state.rs
@@ -1,0 +1,12 @@
+use cosmwasm_schema::cw_serde;
+use cw_storage_plus::{Item, Map};
+
+#[cw_serde]
+pub struct Config {
+    pub ticket_price: u128,
+    pub ticket_denom: String,
+    pub winner: String,
+}
+
+pub const CONFIG: Item<Config> = Item::new("config");
+pub const TICKETS: Item<Vec<String>> = Item::new("tickets");


### PR DESCRIPTION
Contributes to #11

## Summary

- Add an original lottery smart contract example.
- Include ticket purchase, winner draw, winner query behavior, messages, state, and unit coverage.
- Add a schema binary target, remove an unresolved helper-module export, and reject malformed ticket prices instead of treating them as zero.

## Validation

- `git diff --check`

Rust validation was not run in this Windows workspace because `cargo` and `rustc` are not installed on PATH.

## Bounty Contact

GitHub: @alexgduarte
Email: alexduartegomescouto@gmail.com
