### PR TITLE
Add subscription contract example

### DIFF
--- a/subscription/.cargo/config
+++ b/subscription/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --bin schema"

--- a/subscription/.circleci/config.yml
+++ b/subscription/.circleci/config.yml
@@ -1,0 +1,61 @@
+version: 2.1
+
+executors:
+  builder:
+    docker:
+      - image: buildpack-deps:trusty
+
+jobs:
+  docker-image:
+    executor: builder
+    steps:
+      - checkout
+      - setup_remote_docker
+        docker_layer_caching: true
+      - run:
+          name: Build Docker artifact
+          command: docker build --pull -t "cosmwasm/cw-gitpod-base:${CIRCLE_SHA1}" .
+      - run:
+          name: Push application Docker image to docker hub
+          command: |
+            if [ "${CIRCLE_BRANCH}" = "master" ]; then
+              docker tag "cosmwasm/cw-gitpod-base:${CIRCLE_SHA1}" cosmwasm/cw-gitpod-base:latest
+              docker login --password-stdin -u "$DOCKER_USER" \<<<"$DOCKER_PASS"
+              docker push cosmwasm/cw-gitpod-base:latest
+              docker logout
+            fi
+
+  docker-tagged:
+    executor: builder
+    steps:
+      - checkout
+      - setup_remote_docker
+        docker_layer_caching: true
+      - run:
+          name: Push application Docker image to docker hub
+          command: |
+            docker tag "cosmwasm/cw-gitpod-base:${CIRCLE_SHA1}" "cosmwasm/cw-gitpod-base:${CIRCLE_TAG}"
+            docker login --password-stdin -u "$DOCKER_USER" \<<<"$DOCKER_PASS"
+            docker push
+            docker logout
+
+workflows:
+  version: 2
+  test-suite:
+    jobs:
+      # this is now a slow process... let's only run on master
+      - docker-image:
+          filters:
+            branches:
+              only:
+                - master
+      - docker-tagged:
+          filters:
+            tags:
+              only:
+                - /^v.*/
+            branches:
+              ignore:
+                - /.*/
+            requires:
+              - docker-image

--- a/subscription/.circleci/config.yml
+++ b/subscription/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           command: |
             docker tag "cosmwasm/cw-gitpod-base:${CIRCLE_SHA1}" "cosmwasm/cw-gitpod-base:${CIRCLE_TAG}"
             docker login --password-stdin -u "$DOCKER_USER" \<<<"$DOCKER_PASS"
-            docker push
+            docker push "cosmwasm/cw-gitpod-base:${CIRCLE_TAG}"
             docker logout
 
 workflows:

--- a/subscription/.editorconfig
+++ b/subscription/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.rs]
+indent_size = 4

--- a/subscription/.github/workflows/Basic.yml
+++ b/subscription/.github/workflows/Basic.yml
@@ -1,0 +1,75 @@
+# Based on https://github.com/actions-rs/example/blob/master/.github/workflows/quickstart.yml
+
+on: [push, pull_request]
+
+name: Basic
+
+jobs:
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.60.0
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Run unit tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: unit-test
+          args: --locked
+        env:
+          RUST_BACKTRACE: 1
+
+      - name: Compile WASM contract
+        uses: actions-rs/cargo@v1
+        with:
+          command: wasm
+          args: --locked
+        env:
+          RUSTFLAGS: "-C link-arg=-s"
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.60.0
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+
+      - name: Generate Schema
+        uses: actions-rs/cargo@v1
+        with:
+          command: schema
+          args: --locked
+
+      - name: Schema Changes
+        # fails if any changes not committed
+        run: git diff --exit-code schema

--- a/subscription/.github/workflows/Release.yml
+++ b/subscription/.github/workflows/Release.yml
@@ -1,0 +1,35 @@
+name: release wasm
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install cargo-run-script
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-run-script
+      - name: Run cargo optimize
+        uses: actions-rs/cargo@v1
+        with:
+          command: run-script
+          args: optimize
+      - name: Get release ID
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload optimized wasm
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./artifacts/*.wasm
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true

--- a/subscription/.gitignore
+++ b/subscription/.gitignore
@@ -1,0 +1,16 @@
+# Build results
+/target
+/schema
+
+# Cargo+Git helper file (https://github.com/rust-lang/cargo/blob/0.44.1/src/cargo/sources/git/utils.rs#L320-L327)
+.cargo-ok
+
+# Text file backups
+**/*.rs.bk
+
+# macOS
+.DS_Store
+
+# IDEs
+*.iml
+.idea

--- a/subscription/Cargo.toml
+++ b/subscription/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "subscription"
+version = "0.1.0"
+authors = ["gachouchani1999 <gachouchani@ndu.edu.lb>"]
+edition = "2021"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[package.metadata.scripts]
+optimize = """docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  cosmwasm/rust-optimizer:0.12.10
+"""
+
+[dependencies]
+cosmwasm-schema = "1.1.3"
+cosmwasm-std = "1.1.3"
+cosmwasm-storage = "1.1.3"
+cw-storage-plus = "1.0.1"
+cw2 = "1.0.1"
+schemars = "0.8.10"
+serde = { version = "1.0.145", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0.31" }
+
+[dev-dependencies]
+cw-multi-test = "0.16.2"

--- a/subscription/LICENSE
+++ b/subscription/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/subscription/NOTICE
+++ b/subscription/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2023 gachouchani1999 <gachouchani@ndu.edu.lb>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/subscription/README.md
+++ b/subscription/README.md
@@ -1,0 +1,16 @@
+# Hello World Smart Contract 🌍
+
+This smart contract provides an implementation for querying a "Hello World" message.
+
+## Query Message 📩
+
+Retrieve the "Hello World" string from the smart contract using the following function:
+
+```rust
+// contract.rs
+
+pub fn query_hello_world() -> StdResult<HelloWorldResponse> {
+    // Sets the string in the struct to `HelloWorldResponse` and returns it as a response to the query
+    let hello_message = HelloWorldResponse {hello_world_message: "Hello World".to_string()};
+    Ok(hello_message)
+}

--- a/subscription/src/bin/schema.rs
+++ b/subscription/src/bin/schema.rs
@@ -1,0 +1,11 @@
+use cosmwasm_schema::write_api;
+
+use subscription::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg,
+    }
+}

--- a/subscription/src/contract.rs
+++ b/subscription/src/contract.rs
@@ -1,7 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, BankMsg, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, StdResult, Uint128,
+    to_binary, BankMsg, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Order, Response, StdResult,
+    Uint128,
 };
 
 use crate::error::ContractError;
@@ -17,7 +18,10 @@ pub fn instantiate(
 ) -> Result<Response, ContractError> {
     let config = Config {
         provider: msg.provider,
-        price: msg.price.parse().unwrap_or(0),
+        price: msg
+            .price
+            .parse()
+            .map_err(|_| ContractError::InvalidPrice {})?,
         denom: msg.denom,
         interval_seconds: msg.interval_seconds,
     };
@@ -39,9 +43,13 @@ pub fn execute(
     }
 }
 
-pub fn execute_subscribe(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
+pub fn execute_subscribe(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
-    
+
     let coin = info
         .funds
         .iter()
@@ -57,21 +65,56 @@ pub fn execute_subscribe(deps: DepsMut, env: Env, info: MessageInfo) -> Result<R
 
     let msg = BankMsg::Send {
         to_address: config.provider,
-        amount: vec![Coin { denom: config.denom, amount: Uint128::from(config.price) }],
+        amount: vec![Coin {
+            denom: config.denom,
+            amount: Uint128::from(config.price),
+        }],
     };
 
-    Ok(Response::new().add_attribute("action", "subscribe").add_message(msg))
+    Ok(Response::new()
+        .add_attribute("action", "subscribe")
+        .add_message(msg))
 }
 
-pub fn execute_claim(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
+pub fn execute_claim(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
-    if info.sender != config.provider {
+    if info.sender.as_str() != config.provider {
         return Err(ContractError::Unauthorized {});
     }
-    
-    // In a real app we'd iterate over subs or pass the specific user. 
-    // This is a simplified version where the provider claims if any are valid.
-    return Err(ContractError::Unauthorized {}); // Dummy implementation
+
+    let now = env.block.time.seconds();
+    let mut saw_subscription = false;
+    let mut due_subscriber = None;
+
+    for item in SUBSCRIPTIONS.range(deps.storage, None, None, Order::Ascending) {
+        let (subscriber, next_claim) = item?;
+        saw_subscription = true;
+
+        if next_claim <= now {
+            due_subscriber = Some(subscriber);
+            break;
+        }
+    }
+
+    if let Some(subscriber) = due_subscriber {
+        let new_next_claim = now + config.interval_seconds;
+        SUBSCRIPTIONS.save(deps.storage, subscriber.as_str(), &new_next_claim)?;
+
+        return Ok(Response::new()
+            .add_attribute("action", "claim")
+            .add_attribute("subscriber", subscriber)
+            .add_attribute("next_claim", new_next_claim.to_string()));
+    }
+
+    if saw_subscription {
+        Err(ContractError::TooEarlyToClaim {})
+    } else {
+        Err(ContractError::NoSubscription {})
+    }
 }
 
 pub fn execute_cancel(deps: DepsMut, info: MessageInfo) -> Result<Response, ContractError> {
@@ -109,5 +152,69 @@ mod tests {
         let info = mock_info("creator", &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(0, res.messages.len());
+    }
+
+    #[test]
+    fn reject_invalid_price() {
+        let mut deps = mock_dependencies();
+        let msg = InstantiateMsg {
+            provider: "provider".to_string(),
+            price: "not-a-number".to_string(),
+            denom: "earth".to_string(),
+            interval_seconds: 3600,
+        };
+        let info = mock_info("creator", &[]);
+
+        let err = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap_err();
+
+        assert_eq!(err, ContractError::InvalidPrice {});
+    }
+
+    #[test]
+    fn provider_can_claim_due_subscription() {
+        let mut deps = mock_dependencies();
+        let msg = InstantiateMsg {
+            provider: "provider".to_string(),
+            price: "100".to_string(),
+            denom: "earth".to_string(),
+            interval_seconds: 3600,
+        };
+        instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
+
+        let mut env = mock_env();
+        env.block.time = cosmwasm_std::Timestamp::from_seconds(100);
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            mock_info("subscriber", &coins(100, "earth")),
+            ExecuteMsg::Subscribe {},
+        )
+        .unwrap();
+
+        let err = execute(
+            deps.as_mut(),
+            env.clone(),
+            mock_info("provider", &[]),
+            ExecuteMsg::Claim {},
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::TooEarlyToClaim {});
+
+        env.block.time = cosmwasm_std::Timestamp::from_seconds(3700);
+        let res = execute(
+            deps.as_mut(),
+            env,
+            mock_info("provider", &[]),
+            ExecuteMsg::Claim {},
+        )
+        .unwrap();
+
+        assert_eq!(res.attributes[0].value, "claim");
+        assert_eq!(
+            query_sub(deps.as_ref(), "subscriber".to_string())
+                .unwrap()
+                .next_claim,
+            7300
+        );
     }
 }

--- a/subscription/src/contract.rs
+++ b/subscription/src/contract.rs
@@ -1,0 +1,113 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    to_binary, BankMsg, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, StdResult, Uint128,
+};
+
+use crate::error::ContractError;
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, SubResponse};
+use crate::state::{Config, CONFIG, SUBSCRIPTIONS};
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    let config = Config {
+        provider: msg.provider,
+        price: msg.price.parse().unwrap_or(0),
+        denom: msg.denom,
+        interval_seconds: msg.interval_seconds,
+    };
+    CONFIG.save(deps.storage, &config)?;
+    Ok(Response::new().add_attribute("action", "instantiate"))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::Subscribe {} => execute_subscribe(deps, env, info),
+        ExecuteMsg::Claim {} => execute_claim(deps, env, info),
+        ExecuteMsg::Cancel {} => execute_cancel(deps, info),
+    }
+}
+
+pub fn execute_subscribe(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    
+    let coin = info
+        .funds
+        .iter()
+        .find(|c| c.denom == config.denom)
+        .ok_or(ContractError::InsufficientFunds {})?;
+
+    if coin.amount.u128() < config.price {
+        return Err(ContractError::InsufficientFunds {});
+    }
+
+    let next_claim = env.block.time.seconds() + config.interval_seconds;
+    SUBSCRIPTIONS.save(deps.storage, info.sender.as_str(), &next_claim)?;
+
+    let msg = BankMsg::Send {
+        to_address: config.provider,
+        amount: vec![Coin { denom: config.denom, amount: Uint128::from(config.price) }],
+    };
+
+    Ok(Response::new().add_attribute("action", "subscribe").add_message(msg))
+}
+
+pub fn execute_claim(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    if info.sender != config.provider {
+        return Err(ContractError::Unauthorized {});
+    }
+    
+    // In a real app we'd iterate over subs or pass the specific user. 
+    // This is a simplified version where the provider claims if any are valid.
+    return Err(ContractError::Unauthorized {}); // Dummy implementation
+}
+
+pub fn execute_cancel(deps: DepsMut, info: MessageInfo) -> Result<Response, ContractError> {
+    SUBSCRIPTIONS.remove(deps.storage, info.sender.as_str());
+    Ok(Response::new().add_attribute("action", "cancel"))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Subscription { address } => to_binary(&query_sub(deps, address)?),
+    }
+}
+
+fn query_sub(deps: Deps, address: String) -> StdResult<SubResponse> {
+    let next_claim = SUBSCRIPTIONS.load(deps.storage, &address).unwrap_or(0);
+    Ok(SubResponse { next_claim })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::coins;
+
+    #[test]
+    fn proper_initialization() {
+        let mut deps = mock_dependencies();
+        let msg = InstantiateMsg {
+            provider: "provider".to_string(),
+            price: "100".to_string(),
+            denom: "earth".to_string(),
+            interval_seconds: 3600,
+        };
+        let info = mock_info("creator", &[]);
+        let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+        assert_eq!(0, res.messages.len());
+    }
+}

--- a/subscription/src/error.rs
+++ b/subscription/src/error.rs
@@ -9,12 +9,15 @@ pub enum ContractError {
     #[error("Insufficient funds")]
     InsufficientFunds {},
 
+    #[error("Invalid price")]
+    InvalidPrice {},
+
     #[error("Too early to claim")]
     TooEarlyToClaim {},
-    
+
     #[error("No subscription")]
     NoSubscription {},
-    
+
     #[error("Unauthorized")]
     Unauthorized {},
 }

--- a/subscription/src/error.rs
+++ b/subscription/src/error.rs
@@ -1,0 +1,20 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Insufficient funds")]
+    InsufficientFunds {},
+
+    #[error("Too early to claim")]
+    TooEarlyToClaim {},
+    
+    #[error("No subscription")]
+    NoSubscription {},
+    
+    #[error("Unauthorized")]
+    Unauthorized {},
+}

--- a/subscription/src/lib.rs
+++ b/subscription/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod contract;
+mod error;
+pub mod helpers;
+pub mod msg;
+pub mod state;
+
+pub use crate::error::ContractError;

--- a/subscription/src/lib.rs
+++ b/subscription/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod contract;
 mod error;
-pub mod helpers;
 pub mod msg;
 pub mod state;
 

--- a/subscription/src/msg.rs
+++ b/subscription/src/msg.rs
@@ -1,0 +1,28 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+
+#[cw_serde]
+pub struct InstantiateMsg {
+    pub provider: String,
+    pub price: String,
+    pub denom: String,
+    pub interval_seconds: u64,
+}
+
+#[cw_serde]
+pub enum ExecuteMsg {
+    Subscribe {},
+    Claim {},
+    Cancel {},
+}
+
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    #[returns(SubResponse)]
+    Subscription { address: String },
+}
+
+#[cw_serde]
+pub struct SubResponse {
+    pub next_claim: u64,
+}

--- a/subscription/src/state.rs
+++ b/subscription/src/state.rs
@@ -1,0 +1,13 @@
+use cosmwasm_schema::cw_serde;
+use cw_storage_plus::{Item, Map};
+
+#[cw_serde]
+pub struct Config {
+    pub provider: String,
+    pub price: u128,
+    pub denom: String,
+    pub interval_seconds: u64,
+}
+
+pub const CONFIG: Item<Config> = Item::new("config");
+pub const SUBSCRIPTIONS: Map<&str, u64> = Map::new("subscriptions");


### PR DESCRIPTION
Contributes to #11

## Summary

- Add an original subscription smart contract example.
- Include subscribe, provider claim, cancel, subscription query behavior, messages, state, and unit coverage.
- Add a schema binary target, remove an unresolved helper-module export, reject malformed prices, implement a provider-only due-subscription claim path, and fix the tagged Docker push command.

## Validation

- `git diff --check`

Rust validation was not run in this Windows workspace because `cargo` and `rustc` are not installed on PATH.

## Bounty Contact

GitHub: @alexgduarte
Email: alexduartegomescouto@gmail.com
