### PR TITLE
Add multisig-wallet contract example

### DIFF
--- a/multisig-wallet/.cargo/config
+++ b/multisig-wallet/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --bin schema"

--- a/multisig-wallet/.circleci/config.yml
+++ b/multisig-wallet/.circleci/config.yml
@@ -1,0 +1,61 @@
+version: 2.1
+
+executors:
+  builder:
+    docker:
+      - image: buildpack-deps:trusty
+
+jobs:
+  docker-image:
+    executor: builder
+    steps:
+      - checkout
+      - setup_remote_docker
+        docker_layer_caching: true
+      - run:
+          name: Build Docker artifact
+          command: docker build --pull -t "cosmwasm/cw-gitpod-base:${CIRCLE_SHA1}" .
+      - run:
+          name: Push application Docker image to docker hub
+          command: |
+            if [ "${CIRCLE_BRANCH}" = "master" ]; then
+              docker tag "cosmwasm/cw-gitpod-base:${CIRCLE_SHA1}" cosmwasm/cw-gitpod-base:latest
+              docker login --password-stdin -u "$DOCKER_USER" \<<<"$DOCKER_PASS"
+              docker push cosmwasm/cw-gitpod-base:latest
+              docker logout
+            fi
+
+  docker-tagged:
+    executor: builder
+    steps:
+      - checkout
+      - setup_remote_docker
+        docker_layer_caching: true
+      - run:
+          name: Push application Docker image to docker hub
+          command: |
+            docker tag "cosmwasm/cw-gitpod-base:${CIRCLE_SHA1}" "cosmwasm/cw-gitpod-base:${CIRCLE_TAG}"
+            docker login --password-stdin -u "$DOCKER_USER" \<<<"$DOCKER_PASS"
+            docker push
+            docker logout
+
+workflows:
+  version: 2
+  test-suite:
+    jobs:
+      # this is now a slow process... let's only run on master
+      - docker-image:
+          filters:
+            branches:
+              only:
+                - master
+      - docker-tagged:
+          filters:
+            tags:
+              only:
+                - /^v.*/
+            branches:
+              ignore:
+                - /.*/
+            requires:
+              - docker-image

--- a/multisig-wallet/.editorconfig
+++ b/multisig-wallet/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.rs]
+indent_size = 4

--- a/multisig-wallet/.github/workflows/Basic.yml
+++ b/multisig-wallet/.github/workflows/Basic.yml
@@ -1,0 +1,75 @@
+# Based on https://github.com/actions-rs/example/blob/master/.github/workflows/quickstart.yml
+
+on: [push, pull_request]
+
+name: Basic
+
+jobs:
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.60.0
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Run unit tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: unit-test
+          args: --locked
+        env:
+          RUST_BACKTRACE: 1
+
+      - name: Compile WASM contract
+        uses: actions-rs/cargo@v1
+        with:
+          command: wasm
+          args: --locked
+        env:
+          RUSTFLAGS: "-C link-arg=-s"
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.60.0
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+
+      - name: Generate Schema
+        uses: actions-rs/cargo@v1
+        with:
+          command: schema
+          args: --locked
+
+      - name: Schema Changes
+        # fails if any changes not committed
+        run: git diff --exit-code schema

--- a/multisig-wallet/.github/workflows/Release.yml
+++ b/multisig-wallet/.github/workflows/Release.yml
@@ -1,0 +1,35 @@
+name: release wasm
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install cargo-run-script
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-run-script
+      - name: Run cargo optimize
+        uses: actions-rs/cargo@v1
+        with:
+          command: run-script
+          args: optimize
+      - name: Get release ID
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload optimized wasm
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./artifacts/*.wasm
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true

--- a/multisig-wallet/.gitignore
+++ b/multisig-wallet/.gitignore
@@ -1,0 +1,16 @@
+# Build results
+/target
+/schema
+
+# Cargo+Git helper file (https://github.com/rust-lang/cargo/blob/0.44.1/src/cargo/sources/git/utils.rs#L320-L327)
+.cargo-ok
+
+# Text file backups
+**/*.rs.bk
+
+# macOS
+.DS_Store
+
+# IDEs
+*.iml
+.idea

--- a/multisig-wallet/Cargo.toml
+++ b/multisig-wallet/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "multisig-wallet"
+version = "0.1.0"
+authors = ["gachouchani1999 <gachouchani@ndu.edu.lb>"]
+edition = "2021"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[package.metadata.scripts]
+optimize = """docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  cosmwasm/rust-optimizer:0.12.10
+"""
+
+[dependencies]
+cosmwasm-schema = "1.1.3"
+cosmwasm-std = "1.1.3"
+cosmwasm-storage = "1.1.3"
+cw-storage-plus = "1.0.1"
+cw2 = "1.0.1"
+schemars = "0.8.10"
+serde = { version = "1.0.145", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0.31" }
+
+[dev-dependencies]
+cw-multi-test = "0.16.2"

--- a/multisig-wallet/LICENSE
+++ b/multisig-wallet/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/multisig-wallet/NOTICE
+++ b/multisig-wallet/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2023 gachouchani1999 <gachouchani@ndu.edu.lb>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/multisig-wallet/README.md
+++ b/multisig-wallet/README.md
@@ -1,0 +1,16 @@
+# Hello World Smart Contract 🌍
+
+This smart contract provides an implementation for querying a "Hello World" message.
+
+## Query Message 📩
+
+Retrieve the "Hello World" string from the smart contract using the following function:
+
+```rust
+// contract.rs
+
+pub fn query_hello_world() -> StdResult<HelloWorldResponse> {
+    // Sets the string in the struct to `HelloWorldResponse` and returns it as a response to the query
+    let hello_message = HelloWorldResponse {hello_world_message: "Hello World".to_string()};
+    Ok(hello_message)
+}

--- a/multisig-wallet/src/bin/schema.rs
+++ b/multisig-wallet/src/bin/schema.rs
@@ -1,0 +1,11 @@
+use cosmwasm_schema::write_api;
+
+use multisig_wallet::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg,
+    }
+}

--- a/multisig-wallet/src/contract.rs
+++ b/multisig-wallet/src/contract.rs
@@ -1,0 +1,116 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    to_binary, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
+};
+
+use crate::error::ContractError;
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, ProposalResponse};
+use crate::state::{Config, Proposal, CONFIG, PROPOSALS, PROPOSAL_COUNT};
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    let config = Config {
+        signers: msg.signers,
+        threshold: msg.threshold,
+    };
+    CONFIG.save(deps.storage, &config)?;
+    PROPOSAL_COUNT.save(deps.storage, &0)?;
+    Ok(Response::new().add_attribute("action", "instantiate"))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::Propose { msg } => execute_propose(deps, info, msg),
+        ExecuteMsg::Approve { proposal_id } => execute_approve(deps, info, proposal_id),
+        ExecuteMsg::Execute { proposal_id } => execute_exec(deps, proposal_id),
+    }
+}
+
+pub fn execute_propose(deps: DepsMut, info: MessageInfo, msg: CosmosMsg) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    if !config.signers.contains(&info.sender.to_string()) {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    let id = PROPOSAL_COUNT.load(deps.storage)?;
+    PROPOSAL_COUNT.save(deps.storage, &(id + 1))?;
+
+    let prop = Proposal {
+        msg,
+        approvals: vec![info.sender.to_string()],
+    };
+    PROPOSALS.save(deps.storage, id, &prop)?;
+
+    Ok(Response::new().add_attribute("action", "propose"))
+}
+
+pub fn execute_approve(deps: DepsMut, info: MessageInfo, id: u64) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    if !config.signers.contains(&info.sender.to_string()) {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    let mut prop = PROPOSALS.load(deps.storage, id)?;
+    if prop.approvals.contains(&info.sender.to_string()) {
+        return Err(ContractError::AlreadyApproved {});
+    }
+
+    prop.approvals.push(info.sender.to_string());
+    PROPOSALS.save(deps.storage, id, &prop)?;
+
+    Ok(Response::new().add_attribute("action", "approve"))
+}
+
+pub fn execute_exec(deps: DepsMut, id: u64) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    let prop = PROPOSALS.load(deps.storage, id)?;
+
+    if (prop.approvals.len() as u64) < config.threshold {
+        return Err(ContractError::NotEnoughApprovals {});
+    }
+
+    Ok(Response::new().add_message(prop.msg).add_attribute("action", "execute"))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Proposal { id } => to_binary(&query_prop(deps, id)?),
+    }
+}
+
+fn query_prop(deps: Deps, id: u64) -> StdResult<ProposalResponse> {
+    let prop = PROPOSALS.load(deps.storage, id)?;
+    Ok(ProposalResponse { approvals: prop.approvals.len() as u64 })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::{coins, BankMsg};
+
+    #[test]
+    fn proper_initialization() {
+        let mut deps = mock_dependencies();
+        let msg = InstantiateMsg {
+            signers: vec!["a".to_string(), "b".to_string()],
+            threshold: 2,
+        };
+        let info = mock_info("creator", &[]);
+        let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+        assert_eq!(0, res.messages.len());
+    }
+}

--- a/multisig-wallet/src/contract.rs
+++ b/multisig-wallet/src/contract.rs
@@ -15,6 +15,10 @@ pub fn instantiate(
     _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
+    if msg.threshold == 0 || msg.threshold as usize > msg.signers.len() {
+        return Err(ContractError::InvalidThreshold {});
+    }
+
     let config = Config {
         signers: msg.signers,
         threshold: msg.threshold,
@@ -38,7 +42,11 @@ pub fn execute(
     }
 }
 
-pub fn execute_propose(deps: DepsMut, info: MessageInfo, msg: CosmosMsg) -> Result<Response, ContractError> {
+pub fn execute_propose(
+    deps: DepsMut,
+    info: MessageInfo,
+    msg: CosmosMsg,
+) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
     if !config.signers.contains(&info.sender.to_string()) {
         return Err(ContractError::Unauthorized {});
@@ -56,7 +64,11 @@ pub fn execute_propose(deps: DepsMut, info: MessageInfo, msg: CosmosMsg) -> Resu
     Ok(Response::new().add_attribute("action", "propose"))
 }
 
-pub fn execute_approve(deps: DepsMut, info: MessageInfo, id: u64) -> Result<Response, ContractError> {
+pub fn execute_approve(
+    deps: DepsMut,
+    info: MessageInfo,
+    id: u64,
+) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
     if !config.signers.contains(&info.sender.to_string()) {
         return Err(ContractError::Unauthorized {});
@@ -81,7 +93,11 @@ pub fn execute_exec(deps: DepsMut, id: u64) -> Result<Response, ContractError> {
         return Err(ContractError::NotEnoughApprovals {});
     }
 
-    Ok(Response::new().add_message(prop.msg).add_attribute("action", "execute"))
+    PROPOSALS.remove(deps.storage, id);
+
+    Ok(Response::new()
+        .add_message(prop.msg)
+        .add_attribute("action", "execute"))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -93,7 +109,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 
 fn query_prop(deps: Deps, id: u64) -> StdResult<ProposalResponse> {
     let prop = PROPOSALS.load(deps.storage, id)?;
-    Ok(ProposalResponse { approvals: prop.approvals.len() as u64 })
+    Ok(ProposalResponse {
+        approvals: prop.approvals.len() as u64,
+    })
 }
 
 #[cfg(test)]
@@ -112,5 +130,85 @@ mod tests {
         let info = mock_info("creator", &[]);
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(0, res.messages.len());
+    }
+
+    #[test]
+    fn reject_invalid_thresholds() {
+        let mut deps = mock_dependencies();
+        let err = instantiate(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("creator", &[]),
+            InstantiateMsg {
+                signers: vec!["a".to_string(), "b".to_string()],
+                threshold: 0,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::InvalidThreshold {});
+
+        let err = instantiate(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("creator", &[]),
+            InstantiateMsg {
+                signers: vec!["a".to_string(), "b".to_string()],
+                threshold: 3,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::InvalidThreshold {});
+    }
+
+    #[test]
+    fn executed_proposal_cannot_be_replayed() {
+        let mut deps = mock_dependencies();
+        instantiate(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("creator", &[]),
+            InstantiateMsg {
+                signers: vec!["a".to_string(), "b".to_string()],
+                threshold: 2,
+            },
+        )
+        .unwrap();
+
+        let send_msg = CosmosMsg::Bank(BankMsg::Send {
+            to_address: "recipient".to_string(),
+            amount: coins(1, "earth"),
+        });
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("a", &[]),
+            ExecuteMsg::Propose { msg: send_msg },
+        )
+        .unwrap();
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("b", &[]),
+            ExecuteMsg::Approve { proposal_id: 0 },
+        )
+        .unwrap();
+
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("a", &[]),
+            ExecuteMsg::Execute { proposal_id: 0 },
+        )
+        .unwrap();
+        assert_eq!(res.messages.len(), 1);
+
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("a", &[]),
+            ExecuteMsg::Execute { proposal_id: 0 },
+        )
+        .unwrap_err();
+        assert!(matches!(err, ContractError::Std(_)));
     }
 }

--- a/multisig-wallet/src/error.rs
+++ b/multisig-wallet/src/error.rs
@@ -1,0 +1,17 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+
+    #[error("Already approved")]
+    AlreadyApproved {},
+    
+    #[error("Not enough approvals")]
+    NotEnoughApprovals {},
+}

--- a/multisig-wallet/src/error.rs
+++ b/multisig-wallet/src/error.rs
@@ -11,7 +11,10 @@ pub enum ContractError {
 
     #[error("Already approved")]
     AlreadyApproved {},
-    
+
+    #[error("Invalid threshold")]
+    InvalidThreshold {},
+
     #[error("Not enough approvals")]
     NotEnoughApprovals {},
 }

--- a/multisig-wallet/src/lib.rs
+++ b/multisig-wallet/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod contract;
+mod error;
+pub mod helpers;
+pub mod msg;
+pub mod state;
+
+pub use crate::error::ContractError;

--- a/multisig-wallet/src/lib.rs
+++ b/multisig-wallet/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod contract;
 mod error;
-pub mod helpers;
 pub mod msg;
 pub mod state;
 

--- a/multisig-wallet/src/msg.rs
+++ b/multisig-wallet/src/msg.rs
@@ -1,0 +1,27 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::CosmosMsg;
+
+#[cw_serde]
+pub struct InstantiateMsg {
+    pub signers: Vec<String>,
+    pub threshold: u64,
+}
+
+#[cw_serde]
+pub enum ExecuteMsg {
+    Propose { msg: CosmosMsg },
+    Approve { proposal_id: u64 },
+    Execute { proposal_id: u64 },
+}
+
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    #[returns(ProposalResponse)]
+    Proposal { id: u64 },
+}
+
+#[cw_serde]
+pub struct ProposalResponse {
+    pub approvals: u64,
+}

--- a/multisig-wallet/src/state.rs
+++ b/multisig-wallet/src/state.rs
@@ -1,0 +1,19 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::CosmosMsg;
+use cw_storage_plus::{Item, Map};
+
+#[cw_serde]
+pub struct Config {
+    pub signers: Vec<String>,
+    pub threshold: u64,
+}
+
+#[cw_serde]
+pub struct Proposal {
+    pub msg: CosmosMsg,
+    pub approvals: Vec<String>,
+}
+
+pub const CONFIG: Item<Config> = Item::new("config");
+pub const PROPOSALS: Map<u64, Proposal> = Map::new("proposals");
+pub const PROPOSAL_COUNT: Item<u64> = Item::new("proposal_count");


### PR DESCRIPTION
Contributes to #11

## Summary

- Add an original multisig wallet smart contract example.
- Include propose, approve, execute, proposal query behavior, messages, state, and unit coverage.
- Add a schema binary target, validate threshold configuration, and remove executed proposals so approved messages cannot be replayed.

## Validation

- `git diff --check`

Rust validation was not run in this Windows workspace because `cargo` and `rustc` are not installed on PATH.

## Bounty Contact

GitHub: @alexgduarte
Email: alexduartegomescouto@gmail.com
